### PR TITLE
Updated Notebook_Week_1.ipynb

### DIFF
--- a/Notebook_Week_1.ipynb
+++ b/Notebook_Week_1.ipynb
@@ -990,7 +990,11 @@
     "\n",
     "A three party quantum state that has its own name is the GHZ state:\n",
     "\n",
-    "$$ \\rho_{ABC} =  \\frac{1}{\\sqrt{2}} \\Big( \\lvert 000 \\rangle + \\lvert 111 \\rangle \\Big) $$\n",
+    "$$ \\lvert GHZ \\rangle =  \\frac{1}{\\sqrt{2}} \\Big( \\lvert 000 \\rangle + \\lvert 111 \\rangle \\Big) $$\n",
+    "\n",
+    "Written as a density matrix, the state is thus:\n",
+    "\n",
+    "$$ \\rho_{ABC} = \\lvert GHZ \\rangle\\langle GHZ \\rvert$$\n",
     "\n",
     "<b> Compute density matrices $\\rho_{AB}$, $\\rho_{BC}$ and $\\rho_{AC}$ .</b>"
    ]


### PR DESCRIPTION
Fixed a small notation error - a quantum state was labeled with density matrix symbol.
